### PR TITLE
epydoc docstring formatting for rosdocs generation

### DIFF
--- a/scripts/calibrate_arm.py
+++ b/scripts/calibrate_arm.py
@@ -46,7 +46,7 @@ class CalibrateArm(baxter_interface.RobustController):
         """
         Wrapper to run the CalibrateArm RobustController.
 
-        @param limb - Limb to run CalibrateArm on [left/right]
+        @param limb: Limb to run CalibrateArm on [left/right]
         """
         enable_msg = CalibrateArmEnable(isEnabled=True, uid='sdk')
 

--- a/scripts/tare.py
+++ b/scripts/tare.py
@@ -46,7 +46,7 @@ class Tare(baxter_interface.RobustController):
         """
         Wrapper to run the Tare RobustController.
 
-        @param limb - Limb to run tare on [left/right]
+        @param limb: Limb to run tare on [left/right]
         """
         enable_msg = TareEnable(isEnabled=True, uid='sdk')
         enable_msg.data.tuneGravitySpring = True

--- a/scripts/update_robot.py
+++ b/scripts/update_robot.py
@@ -101,7 +101,7 @@ class Updater(object):
         """
         Command the robot to launch the update with the given uuid.
 
-        @param uuid - uuid of the update to start.
+        @param uuid: uuid of the update to start.
         """
         if not any([u.uuid == uuid for u in self._avail_updates.sources]):
             raise OSError(errno.EINVAL, "Invalid update uuid '%s'" % (uuid,))
@@ -119,8 +119,8 @@ def run_update(updater, uuid):
     """
     Run and monitor the progress of an update.
 
-    @param updater  - Instance of Updater to use.
-    @param uuid     - update uuid.
+    @param updater: Instance of Updater to use.
+    @param uuid: update uuid.
     """
 
     # Work around lack of a nonlocal keyword in python 2.x


### PR DESCRIPTION
Formatting mostly params in the docstrings to conform to epydoc syntax, so rosdoc_lite can properly parse and auto generate docs in the future.
