### PR TITLE
Add Gripper-attach Prompt to Update Tool

### DIFF
--- a/scripts/update_robot.py
+++ b/scripts/update_robot.py
@@ -209,6 +209,13 @@ def main():
         if uuid == '':
             print "Error:  no update uuid specified"
             return 1
+        msg = ("NOTE: Please plug in any Rethink Electric Parallel Grippers\n"
+               "      into the robot now, so that the Gripper Firmware\n"
+               "      can be automatically upgraded with the robot.\n")
+        print (msg)
+        raw_input("Press <Enter> to Continue...")
+        if rospy.is_shutdown():
+            return 0
         return run_update(updater, uuid)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adds prompt to attach gripper to update tool before running update.
Gripper Firmwares are upgraded during the robot update process if
they are attached -- this is recommended operating procedure.
Otherwise, users must go into the robot FSM to Update Gripper
Firmware.

NOTE: raw_input() is not Python 3 compatible; nor does it exit
      immediately upon KeyboardInterrupt (Ctrl^C)
