### PR TITLE
Basic python changes for Noetic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.5)
 project(baxter_tools)
 
 find_package(catkin
@@ -26,11 +26,21 @@ catkin_package(
   baxter_maintenance_msgs
 )
 
-install(
-  DIRECTORY scripts/
+catkin_install_python(PROGRAMS 
+    scripts/calibrate_arm.py
+    scripts/camera_control.py
+    scripts/enable_robot.py 
+    scripts/smoke_test.py
+    scripts/tare.py
+    scripts/tuck_arms.py
+    scripts/update_robot.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-  USE_SOURCE_PERMISSIONS
-)
+  )
+# install(
+#   DIRECTORY scripts/
+#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+#   USE_SOURCE_PERMISSIONS
+# )
 
 install(
   DIRECTORY share/

--- a/scripts/calibrate_arm.py
+++ b/scripts/calibrate_arm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python
 
 # Copyright (c) 2013-2015, Rethink Robotics
 # All rights reserved.
@@ -101,7 +101,7 @@ def main():
     error = None
     try:
         cat.run()
-    except Exception, e:
+    except Exception as e:
         error = e.strerror
     finally:
         try:

--- a/scripts/camera_control.py
+++ b/scripts/camera_control.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python
 
 # Copyright (c) 2013-2015, Rethink Robotics
 # All rights reserved.

--- a/scripts/enable_robot.py
+++ b/scripts/enable_robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python
 
 # Copyright (c) 2013-2015, Rethink Robotics
 # All rights reserved.
@@ -67,7 +67,7 @@ def main():
     try:
         for act in args.actions:
             if act == 'state':
-                print rs.state()
+                print (rs.state())
             elif act == 'enable':
                 rs.enable()
             elif act == 'disable':
@@ -76,7 +76,7 @@ def main():
                 rs.reset()
             elif act == 'stop':
                 rs.stop()
-    except Exception, e:
+    except Exception as e:
         rospy.logerr(e.strerror)
 
     return 0

--- a/scripts/tare.py
+++ b/scripts/tare.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python
 
 # Copyright (c) 2013-2015, Rethink Robotics
 # All rights reserved.
@@ -102,7 +102,7 @@ def main():
     error = None
     try:
         tt.run()
-    except Exception, e:
+    except Exception as e:
         error = e.strerror
     finally:
         try:

--- a/scripts/tuck_arms.py
+++ b/scripts/tuck_arms.py
@@ -155,7 +155,7 @@ class Tuck(object):
         if any(disabled.values()):
             [pub.publish(Empty()) for pub in self._disable_pub.values()]
         while (any(self._arm_state['tuck'][limb] != goal
-                   for limb, goal in tuck.viewitems())
+                   for limb, goal in tuck.items())
                and not rospy.is_shutdown()):
             if self._rs.state().enabled == False:
                 self._enable_pub.publish(True)

--- a/scripts/update_robot.py
+++ b/scripts/update_robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python
 
 # Copyright (c) 2013-2015, Rethink Robotics
 # All rights reserved.
@@ -164,9 +164,9 @@ def run_update(updater, uuid):
 
     try:
         updater.command_update(uuid)
-    except OSError, e:
+    except OSError as e:
         if e.errno == errno.EINVAL:
-            print e.strerror
+            print (e.strerror)
             return 1
         raise
 
@@ -176,9 +176,9 @@ def run_update(updater, uuid):
             timeout=5 * 60,
             timeout_msg="Timeout waiting for update to succeed"
         )
-    except Exception, e:
+    except Exception as e:
         if not (hasattr(e, 'errno') and e.errno == errno.ESHUTDOWN):
-            print e.strerror
+            print (e.strerror)
         nl.rc = 1
 
     return nl.rc
@@ -266,7 +266,7 @@ def main():
         return 0
     elif cmd == 'update':
         if uuid == '':
-            print "Error:  no update uuid specified"
+            print ("Error:  no update uuid specified")
             return 1
         msg = ("NOTE: Please plug in any Rethink Electric Parallel Grippers\n"
                "      into the robot now, so that the Gripper Firmware\n"


### PR DESCRIPTION
This is one of several pull request for getting the Baxter simulation to work in ROS Noetic with python 3 and Qt5.  It is intended to be merged into a `noetic_devel` branch.  There is an update from another repository that is required for the simulator to work in Noetic:

[https://github.com/EmaroLab/baxter_simulator](https://github.com/EmaroLab/baxter_simulator)

The python scripts are set use python 2 and override python3.  This needed to be fixed.  There were a couple of other minor edits to make the scripts work for python3 as well.  Finally, the installation method in CMakeLists.txt was updated.
